### PR TITLE
Adds Markdown file previewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,20 @@ To load the README files in the current directory
 Load README files in a specify directory and sub directories
 
 ```console
-  rdx -path "./my-directory"
+  rdx -path ./my-directory
 ```
 Load README with max recursive depth
 
 ```console
-  rdx -path "./my-directory" -d 3
+  rdx -path ./my-directory -d 3
 ```
 To specify a different port for previewing the README files
 ```console
-   rdx -path "./my-directory" -p 8000
+   rdx -path ./my-directory -p 8000
+```
+To open and preview any Markdown file run
+```console
+   rdx -open my-file.md
 ```
 
 ## LICENSE

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 )
 
 type config struct {
+    open string
     root string
     depth int
     port int
@@ -41,9 +42,11 @@ func main() {
     root := flag.String("path", ".", "Directory to search");
     port := flag.Int("p", 4559, "PORT to preview");
     depth := flag.Int("d", 3, "Maximum recursive depth");
+    open := flag.String("open", "", "Specify a Markdown file to open for previewing");
     flag.Parse();
     
     configData = config {
+        open: *open,
         root: *root, 
         depth: *depth, 
         port: *port,

--- a/main.go
+++ b/main.go
@@ -67,9 +67,18 @@ func main() {
 
 func run() error {
     
+    // Open a specify markdown file for previewing
+    if configData.open != "" && isMarkdown(configData.open) {
+        err := parseMarkdown(configData.open);
+        if err != nil {
+            return err;
+        }
+        startServer(configData.port);
+        return nil;
+    }
     // If root is a README parse README
     if isMarkdownReadMe(configData.root) {
-        err := parseReadme(configData.root);
+        err := parseMarkdown(configData.root);
         if err != nil {
             return err;
         }
@@ -91,7 +100,15 @@ func isMarkdownReadMe(path string) bool {
     return false;
 }
 
-func parseReadme(root string) error {
+func isMarkdown(filename string) bool {
+    ext := filepath.Ext(filename);
+    if ext == ".md" {
+        return true;
+    }
+    return false;
+}
+
+func parseMarkdown(root string) error {
     content, err := ioutil.ReadFile(root);
     if err != nil {
         return err
@@ -125,7 +142,7 @@ func walkPath(path string, maxDepth int) error {
         base := filepath.Base(path);
         base = strings.ToLower(base);
         if base == "readme.md" {
-            parseReadme(path);
+            parseMarkdown(path);
         }
         return nil
     });


### PR DESCRIPTION
Implements a Markdown file previewer, the RDX CLI tool can now be use to parse and open any Markdown file for previewing in the browser